### PR TITLE
fix(generator): annotate TImpl with [DynamicallyAccessedMembers] on Add{Service}Cache (closes #7)

### DIFF
--- a/samples/ZeroAlloc.Cache.AotSmoke/ZeroAlloc.Cache.AotSmoke.csproj
+++ b/samples/ZeroAlloc.Cache.AotSmoke/ZeroAlloc.Cache.AotSmoke.csproj
@@ -7,14 +7,7 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <OptimizationPreference>Size</OptimizationPreference>
 
-    <!--
-      IL2091 is temporarily suppressed: the generator emits Add{Service}Cache<TImpl>
-      without [DynamicallyAccessedMembers(PublicConstructors)] on TImpl, which
-      propagates an AOT warning from AddTransient<T>. Tracked as #7 — remove
-      this suppression once the generator emits the annotation.
-    -->
-    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2067;IL2075;IL3050;IL3051</WarningsAsErrors>
-    <NoWarn>$(NoWarn);IL2091</NoWarn>
+    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2067;IL2075;IL2091;IL3050;IL3051</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ZeroAlloc.Cache.Generator/CacheWriter.cs
+++ b/src/ZeroAlloc.Cache.Generator/CacheWriter.cs
@@ -249,7 +249,12 @@ internal static class CacheWriter
 
         sb.AppendLine("public static partial class CacheServiceCollectionExtensions");
         sb.AppendLine("{");
-        sb.AppendLine($"    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection {methodName}<TImpl>(");
+        sb.AppendLine($"    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection {methodName}<");
+        // IL2091: TImpl flows into AddTransient<T> which requires PublicConstructors.
+        // Without this annotation consumers' publish fails when they promote IL2091 to error.
+        sb.AppendLine("        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(");
+        sb.AppendLine("            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]");
+        sb.AppendLine("        TImpl>(");
         sb.AppendLine("        this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)");
         sb.AppendLine($"        where TImpl : class, {ifaceFqn}");
         sb.AppendLine("    {");

--- a/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.GlobalNamespace_GeneratesProxy#IGlobalService.Cache.g.verified.cs
+++ b/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.GlobalNamespace_GeneratesProxy#IGlobalService.Cache.g.verified.cs
@@ -32,7 +32,10 @@ internal sealed class IGlobalServiceCacheProxy : global::IGlobalService
 
 public static partial class CacheServiceCollectionExtensions
 {
-    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddGlobalServiceCache<TImpl>(
+    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddGlobalServiceCache<
+        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TImpl>(
         this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         where TImpl : class, global::IGlobalService
     {

--- a/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.InterfaceLevel_IMemoryCache_SingleMethod#T_IMyService.Cache.g.verified.cs
+++ b/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.InterfaceLevel_IMemoryCache_SingleMethod#T_IMyService.Cache.g.verified.cs
@@ -34,7 +34,10 @@ internal sealed class IMyServiceCacheProxy : global::T.IMyService
 
 public static partial class CacheServiceCollectionExtensions
 {
-    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<TImpl>(
+    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<
+        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TImpl>(
         this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         where TImpl : class, global::T.IMyService
     {

--- a/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.InterfaceLevel_WithPassthrough_GeneratesProxy#T_IMyService.Cache.g.verified.cs
+++ b/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.InterfaceLevel_WithPassthrough_GeneratesProxy#T_IMyService.Cache.g.verified.cs
@@ -37,7 +37,10 @@ internal sealed class IMyServiceCacheProxy : global::T.IMyService
 
 public static partial class CacheServiceCollectionExtensions
 {
-    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<TImpl>(
+    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<
+        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TImpl>(
         this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         where TImpl : class, global::T.IMyService
     {

--- a/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.MaxEntries_UsesIsolatedMemoryCache#T_IMyService.Cache.g.verified.cs
+++ b/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.MaxEntries_UsesIsolatedMemoryCache#T_IMyService.Cache.g.verified.cs
@@ -34,7 +34,10 @@ internal sealed class IMyServiceCacheProxy : global::T.IMyService
 
 public static partial class CacheServiceCollectionExtensions
 {
-    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<TImpl>(
+    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<
+        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TImpl>(
         this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         where TImpl : class, global::T.IMyService
     {

--- a/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.MaxEntries_WithHybridCache_MixedMethods#T_IMyService.Cache.g.verified.cs
+++ b/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.MaxEntries_WithHybridCache_MixedMethods#T_IMyService.Cache.g.verified.cs
@@ -50,7 +50,10 @@ internal sealed class IMyServiceCacheProxy : global::T.IMyService
 
 public static partial class CacheServiceCollectionExtensions
 {
-    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<TImpl>(
+    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<
+        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TImpl>(
         this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         where TImpl : class, global::T.IMyService
     {

--- a/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.MethodLevel_Override_ShadowsInterfaceLevel#T_IMyService.Cache.g.verified.cs
+++ b/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.MethodLevel_Override_ShadowsInterfaceLevel#T_IMyService.Cache.g.verified.cs
@@ -44,7 +44,10 @@ internal sealed class IMyServiceCacheProxy : global::T.IMyService
 
 public static partial class CacheServiceCollectionExtensions
 {
-    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<TImpl>(
+    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<
+        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TImpl>(
         this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         where TImpl : class, global::T.IMyService
     {

--- a/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.PurePassthrough_AllNonGenericReturns_GeneratesProxy#T_IMyService.Cache.g.verified.cs
+++ b/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.PurePassthrough_AllNonGenericReturns_GeneratesProxy#T_IMyService.Cache.g.verified.cs
@@ -24,7 +24,10 @@ internal sealed class IMyServiceCacheProxy : global::T.IMyService
 
 public static partial class CacheServiceCollectionExtensions
 {
-    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<TImpl>(
+    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<
+        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TImpl>(
         this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         where TImpl : class, global::T.IMyService
     {

--- a/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.Sliding_IMemoryCache_UsesMemoryCacheEntryOptions#T_IMyService.Cache.g.verified.cs
+++ b/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.Sliding_IMemoryCache_UsesMemoryCacheEntryOptions#T_IMyService.Cache.g.verified.cs
@@ -35,7 +35,10 @@ internal sealed class IMyServiceCacheProxy : global::T.IMyService
 
 public static partial class CacheServiceCollectionExtensions
 {
-    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<TImpl>(
+    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<
+        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TImpl>(
         this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         where TImpl : class, global::T.IMyService
     {

--- a/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.Sliding_WithMaxEntries_UsesSlidingExpirationAndSize#T_IMyService.Cache.g.verified.cs
+++ b/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.Sliding_WithMaxEntries_UsesSlidingExpirationAndSize#T_IMyService.Cache.g.verified.cs
@@ -34,7 +34,10 @@ internal sealed class IMyServiceCacheProxy : global::T.IMyService
 
 public static partial class CacheServiceCollectionExtensions
 {
-    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<TImpl>(
+    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<
+        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TImpl>(
         this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         where TImpl : class, global::T.IMyService
     {

--- a/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.UseHybridCache_GeneratesHybridProxy#T_IMyService.Cache.g.verified.cs
+++ b/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.UseHybridCache_GeneratesHybridProxy#T_IMyService.Cache.g.verified.cs
@@ -34,7 +34,10 @@ internal sealed class IMyServiceCacheProxy : global::T.IMyService
 
 public static partial class CacheServiceCollectionExtensions
 {
-    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<TImpl>(
+    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<
+        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TImpl>(
         this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         where TImpl : class, global::T.IMyService
     {

--- a/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.UseHybridCache_NoParams_GeneratesHybridProxy#T_IMyService.Cache.g.verified.cs
+++ b/tests/ZeroAlloc.Cache.Generator.Tests/Snapshots/SnapshotTests.UseHybridCache_NoParams_GeneratesHybridProxy#T_IMyService.Cache.g.verified.cs
@@ -34,7 +34,10 @@ internal sealed class IMyServiceCacheProxy : global::T.IMyService
 
 public static partial class CacheServiceCollectionExtensions
 {
-    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<TImpl>(
+    public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddMyServiceCache<
+        [global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TImpl>(
         this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         where TImpl : class, global::T.IMyService
     {


### PR DESCRIPTION
Closes #7.

The generator now emits `[DynamicallyAccessedMembers(PublicConstructors)]` on the `TImpl` type parameter of the generated DI extension. This matches the annotation on `AddTransient<T>` and clears the `IL2091` that ILC was raising at every consumer publish.

Also removes the `NoWarn IL2091` workaround from the AOT smoke sample — it should now pass on the strict per-call error list.