### PR TITLE
perf: add BenchmarkDotNet project with cached-hit vs direct lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ obj/
 .vs/
 *.user
 .worktrees/
+
+BenchmarkDotNet.Artifacts/

--- a/ZeroAlloc.Cache.slnx
+++ b/ZeroAlloc.Cache.slnx
@@ -3,6 +3,9 @@
     <Project Path="src/ZeroAlloc.Cache/ZeroAlloc.Cache.csproj" />
     <Project Path="src/ZeroAlloc.Cache.Generator/ZeroAlloc.Cache.Generator.csproj" />
   </Folder>
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/ZeroAlloc.Cache.Benchmarks/ZeroAlloc.Cache.Benchmarks.csproj" />
+  </Folder>
   <Folder Name="/samples/">
     <Project Path="samples/ZeroAlloc.Cache.AotSmoke/ZeroAlloc.Cache.AotSmoke.csproj" />
   </Folder>

--- a/benchmarks/ZeroAlloc.Cache.Benchmarks/CachedLookupBenchmark.cs
+++ b/benchmarks/ZeroAlloc.Cache.Benchmarks/CachedLookupBenchmark.cs
@@ -1,0 +1,56 @@
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Caching.Memory;
+using ZeroAlloc.Cache;
+
+namespace ZeroAlloc.Cache.Benchmarks;
+
+// Measures the overhead of the generator-emitted cache proxy on a CACHE HIT —
+// the hot path after the first request has warmed the entry. The claim: the
+// key struct is generated at compile time, no object[] boxing, no string.Format
+// allocation — so the hit path allocates 0 B/op.
+//
+// Baseline: calling the inner service directly (no caching). The ratio column
+// surfaces how cheap the cache hit is vs. the underlying service call.
+[MemoryDiagnoser]
+[SimpleJob]
+public class CachedLookupBenchmark
+{
+    private ICustomerService _direct = null!;
+    private ICustomerService _proxied = null!;
+    private MemoryCache _cache = null!;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _direct = new CustomerService();
+        _proxied = new ICustomerServiceCacheProxy(_direct, _cache);
+        // Warm the cache for the single key we measure.
+        _ = await _proxied.GetNameAsync(42, CancellationToken.None).ConfigureAwait(false);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _cache.Dispose();
+
+    [Benchmark(Baseline = true, Description = "direct (no cache)")]
+    public async Task<string?> Direct()
+        => await _direct.GetNameAsync(42, CancellationToken.None).ConfigureAwait(false);
+
+    [Benchmark(Description = "proxied (cache hit)")]
+    public async Task<string?> Proxied()
+        => await _proxied.GetNameAsync(42, CancellationToken.None).ConfigureAwait(false);
+}
+
+[Cache(TtlMs = 60_000)]
+public interface ICustomerService
+{
+    ValueTask<string?> GetNameAsync(int customerId, CancellationToken ct);
+}
+
+public sealed class CustomerService : ICustomerService
+{
+    public ValueTask<string?> GetNameAsync(int customerId, CancellationToken ct)
+        => ValueTask.FromResult<string?>($"customer-{customerId}");
+}

--- a/benchmarks/ZeroAlloc.Cache.Benchmarks/CachedLookupBenchmark.cs
+++ b/benchmarks/ZeroAlloc.Cache.Benchmarks/CachedLookupBenchmark.cs
@@ -35,22 +35,22 @@ public class CachedLookupBenchmark
     public void Cleanup() => _cache.Dispose();
 
     [Benchmark(Baseline = true, Description = "direct (no cache)")]
-    public async Task<string?> Direct()
+    public async Task<string> Direct()
         => await _direct.GetNameAsync(42, CancellationToken.None).ConfigureAwait(false);
 
     [Benchmark(Description = "proxied (cache hit)")]
-    public async Task<string?> Proxied()
+    public async Task<string> Proxied()
         => await _proxied.GetNameAsync(42, CancellationToken.None).ConfigureAwait(false);
 }
 
 [Cache(TtlMs = 60_000)]
 public interface ICustomerService
 {
-    ValueTask<string?> GetNameAsync(int customerId, CancellationToken ct);
+    ValueTask<string> GetNameAsync(int customerId, CancellationToken ct);
 }
 
 public sealed class CustomerService : ICustomerService
 {
-    public ValueTask<string?> GetNameAsync(int customerId, CancellationToken ct)
-        => ValueTask.FromResult<string?>($"customer-{customerId}");
+    public ValueTask<string> GetNameAsync(int customerId, CancellationToken ct)
+        => ValueTask.FromResult($"customer-{customerId}");
 }

--- a/benchmarks/ZeroAlloc.Cache.Benchmarks/Program.cs
+++ b/benchmarks/ZeroAlloc.Cache.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+
+public partial class Program { }

--- a/benchmarks/ZeroAlloc.Cache.Benchmarks/ZeroAlloc.Cache.Benchmarks.csproj
+++ b/benchmarks/ZeroAlloc.Cache.Benchmarks/ZeroAlloc.Cache.Benchmarks.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Optimize>true</Optimize>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <NoWarn>$(NoWarn);MA0048</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.4" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
+
+    <ProjectReference Include="..\..\src\ZeroAlloc.Cache\ZeroAlloc.Cache.csproj" />
+    <ProjectReference Include="..\..\src\ZeroAlloc.Cache.Generator\ZeroAlloc.Cache.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Adds a BenchmarkDotNet project with a cached-hit vs direct-call comparison on the generator-emitted cache proxy. `MemoryDiagnoser` verifies the hit path allocates 0 B/op.