### PR TITLE
docs: add GitHub Sponsors badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ZeroAlloc.Cache
 
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/MarcelRoozekrans?style=flat&logo=githubsponsors&color=ea4aaa&label=Sponsor)](https://github.com/sponsors/MarcelRoozekrans)
+
+
 Source-generated zero-allocation caching proxy from an annotated interface.
 
 Add `[Cache]` to an interface and a Roslyn source generator emits a proxy class that transparently intercepts every method call, returning a cached result on hit with **no heap allocation on the cache-hit path**. Backed by `IMemoryCache` by default, with optional `HybridCache` (L1 + L2) opt-in per method. AOT-safe.


### PR DESCRIPTION
Adds GitHub Sponsors badge to the README.