### PR TITLE
fix: pack generator DLL under analyzers/dotnet/cs

### DIFF
--- a/src/ZeroAlloc.Cache.Generator/ZeroAlloc.Cache.Generator.csproj
+++ b/src/ZeroAlloc.Cache.Generator/ZeroAlloc.Cache.Generator.csproj
@@ -10,9 +10,33 @@
     <Version>0.0.0-local</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <NoWarn>$(NoWarn);RS2008</NoWarn>
+
+    <!--
+      Source-generator packaging: ship the generator DLL under analyzers/dotnet/cs so
+      Roslyn loads it as an analyzer. Without IncludeBuildOutput=false the build output
+      ends up under lib/ and consumers silently get no source generator.
+    -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+  </ItemGroup>
+  <!--
+    Pack the generator DLL under analyzers/dotnet/cs. Without this, dotnet pack falls back
+    to the default lib/<tfm>/ layout and Roslyn does not load the generator at all.
+  -->
+  <ItemGroup>
+    <None Include="$(OutputPath)\$(AssemblyName).dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).pdb"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false"
+          Condition="Exists('$(OutputPath)\$(AssemblyName).pdb')" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
`ZeroAlloc.Cache.Generator` was packing the generator DLL under `lib/netstandard2.0/` instead of `analyzers/dotnet/cs/`. Roslyn only loads source generators from the analyzers path, so consumers of the package got an empty `obj/Debug/<tfm>/generated/` and silently received no generated proxy code.

Three property additions + one ItemGroup, matching the canonical pattern used by `ZeroAlloc.Mediator.Generator` and `ZeroAlloc.EventSourcing.Generators`:

- `IncludeBuildOutput=false` — suppresses the default `lib/<tfm>/` output
- `DevelopmentDependency=true` — marks the package as build-only
- `SuppressDependenciesWhenPacking=true` — keeps Roslyn deps out of the consumer's graph
- `<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" />` — places the DLL where Roslyn looks

Related: ZeroAlloc-Net/ZeroAlloc.Rest#67 — the same root cause across the ecosystem.

## Test plan
- [ ] CI green
- [ ] `dotnet pack` produces `ZeroAlloc.Cache.Generator.nupkg` with the DLL at `analyzers/dotnet/cs/` and **not** at `lib/netstandard2.0/`
- [ ] Wire the published package into a fresh project and verify a `[Cache]`-attributed interface produces generated code

🤖 Generated with [Claude Code](https://claude.com/claude-code)