### PR TITLE
feat: bundle source generator into ZeroAlloc.Cache package

### DIFF
--- a/src/ZeroAlloc.Cache/ZeroAlloc.Cache.csproj
+++ b/src/ZeroAlloc.Cache/ZeroAlloc.Cache.csproj
@@ -16,6 +16,12 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="9.3.0" />
   </ItemGroup>
+  <!--
+    Bundle the source generator into the NuGet package so consumers get it by
+    referencing only ZeroAlloc.Cache. The standalone ZeroAlloc.Cache.Generator
+    package is still published for backwards compatibility, but new consumers
+    should reference the main package only.
+  -->
   <ItemGroup>
     <ProjectReference
       Include="..\ZeroAlloc.Cache.Generator\ZeroAlloc.Cache.Generator.csproj"
@@ -23,4 +29,12 @@
       ReferenceOutputAssembly="false"
       PrivateAssets="all" />
   </ItemGroup>
+  <Target Name="IncludeGeneratorInPackage" BeforeTargets="_GetPackageFiles">
+    <ItemGroup>
+      <None Include="$(MSBuildThisFileDirectory)..\ZeroAlloc.Cache.Generator\bin\$(Configuration)\netstandard2.0\ZeroAlloc.Cache.Generator.dll"
+            Pack="true"
+            PackagePath="analyzers/dotnet/cs"
+            Visible="false" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
Until now consumers had to install both `ZeroAlloc.Cache` and `ZeroAlloc.Cache.Generator` (with the right `OutputItemType` / `PrivateAssets` flags) to get a working setup. Bundling the generator DLL inside the main library's NuGet package under `analyzers/dotnet/cs/` means **a single `PackageReference` is now enough**.

`ZeroAlloc.Cache.Generator` continues to publish as a standalone package for backwards compatibility with existing direct `PackageReference`s. New consumers should reference only `ZeroAlloc.Cache`.

## What changes
- Add `IncludeGeneratorInPackage` MSBuild target that packs the generator DLL under `analyzers/dotnet/cs/` in the main library's nupkg

## Test plan
- [ ] CI green
- [ ] `dotnet pack` produces `ZeroAlloc.Cache.nupkg` containing the generator DLL at `analyzers/dotnet/cs/`
- [ ] In a fresh project with only `<PackageReference Include="ZeroAlloc.Cache">`, a `[Cache]`-attributed interface produces generated proxy code
- [ ] Existing setups with both packages referenced continue to work (Roslyn dedupes same-version analyzers)

Related: ZeroAlloc-Net/ZeroAlloc.Rest#67

🤖 Generated with [Claude Code](https://claude.com/claude-code)