### PR TITLE
feat: lock public API surface (PublicApiAnalyzers + api-compat gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,9 @@ jobs:
 
       - name: Run AOT binary
         run: ./aot-out/ZeroAlloc.Cache.AotSmoke
+
+  api-compat:
+    uses: ZeroAlloc-Net/.github/.github/workflows/api-compat.yml@main
+    with:
+      package-id: ZeroAlloc.Cache
+      csproj-path: src/ZeroAlloc.Cache/ZeroAlloc.Cache.csproj

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017</WarningsAsErrors>
 
     <!-- NuGet package metadata (shared across all packable projects) -->
     <Authors>Marcel Roozekrans</Authors>

--- a/src/ZeroAlloc.Cache/PublicAPI.Shipped.txt
+++ b/src/ZeroAlloc.Cache/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ZeroAlloc.Cache/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.Cache/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ZeroAlloc.Cache/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.Cache/PublicAPI.Unshipped.txt
@@ -1,1 +1,11 @@
 #nullable enable
+ZeroAlloc.Cache.CacheAttribute
+ZeroAlloc.Cache.CacheAttribute.CacheAttribute() -> void
+ZeroAlloc.Cache.CacheAttribute.MaxEntries.get -> int
+ZeroAlloc.Cache.CacheAttribute.MaxEntries.init -> void
+ZeroAlloc.Cache.CacheAttribute.Sliding.get -> bool
+ZeroAlloc.Cache.CacheAttribute.Sliding.init -> void
+ZeroAlloc.Cache.CacheAttribute.TtlMs.get -> int
+ZeroAlloc.Cache.CacheAttribute.TtlMs.init -> void
+ZeroAlloc.Cache.CacheAttribute.UseHybridCache.get -> bool
+ZeroAlloc.Cache.CacheAttribute.UseHybridCache.init -> void

--- a/src/ZeroAlloc.Cache/ZeroAlloc.Cache.csproj
+++ b/src/ZeroAlloc.Cache/ZeroAlloc.Cache.csproj
@@ -29,6 +29,16 @@
       ReferenceOutputAssembly="false"
       PrivateAssets="all" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
   <Target Name="IncludeGeneratorInPackage" BeforeTargets="_GetPackageFiles">
     <ItemGroup>
       <None Include="$(MSBuildThisFileDirectory)..\ZeroAlloc.Cache.Generator\bin\$(Configuration)\netstandard2.0\ZeroAlloc.Cache.Generator.dll"


### PR DESCRIPTION
## Summary
Adopts the public-API gating pattern from [ZeroAlloc.Authorization](https://github.com/ZeroAlloc-Net/ZeroAlloc.Authorization). Phase B fan-out using the reusable api-compat workflow at [ZeroAlloc-Net/.github](https://github.com/ZeroAlloc-Net/.github/blob/main/.github/workflows/api-compat.yml).

## What's added
- `Microsoft.CodeAnalysis.PublicApiAnalyzers` analyzer + `PublicAPI.Shipped.txt` (empty) / `PublicAPI.Unshipped.txt` (current public surface — 10 entries, single `CacheAttribute` type identical across net8/9/10)
- `RS0016` / `RS0017` elevated to errors
- `api-compat` CI job consuming the reusable workflow (4-line `uses:` reference)

## No-op until 1.0
ZeroAlloc.Cache is currently `0.0.1` on nuget.org. The reusable api-compat workflow handles "no stable release" cleanly, so the new `api-compat` job will be a no-op until Cache 1.0 publishes. Adopting now is still useful: RS0016/RS0017 gate at compile time as soon as the analyzer is wired.

## Sibling PRs (Phase B fan-out)
- ZeroAlloc.Authorization #5
- ZeroAlloc.AsyncEvents #47
- ZeroAlloc.EventSourcing #113
- ZeroAlloc.Saga #17

## At next 1.x release
After the next 1.x publishes, move `PublicAPI.Unshipped.txt` content to `PublicAPI.Shipped.txt`.

## Test plan
- [x] `dotnet build -c Release --no-incremental` clean (0 warnings, 0 errors)
- [x] `dotnet test -c Release --no-build` passes (28/28)
- [ ] CI green (lint-commits, build, aot-smoke, api-compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)