### PR TITLE
ci: remove auto-publish to nuget on every main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,6 @@ jobs:
           -c Release -p:Version=${{ steps.gitversion.outputs.semver }}
           --no-build -o ./artifacts
 
-      - name: Push to NuGet
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: |
-          dotnet nuget push ./artifacts/*.nupkg \
-            --source https://api.nuget.org/v3/index.json \
-            --api-key ${{ secrets.NUGET_API_KEY }} \
-            --skip-duplicate
-
   aot-smoke:
     runs-on: ubuntu-latest
     # Publishes samples/ZeroAlloc.Cache.AotSmoke with PublishAot=true. The


### PR DESCRIPTION
## Summary
- Removed the `Push to NuGet` step from `.github/workflows/ci.yml` that ran `dotnet nuget push` on every main push.
- Build, test, and pack steps remain intact; only the publish step is gone.

## Why
Per org-wide decision: only release-please-shepherded releases should publish to NuGet. The auto-publish step was shipping versions on every main push, outside release-please's bookkeeping.

## Test plan
- [ ] CI runs on this PR (build / test / pack succeed; no push step executes)
- [ ] After merge, confirm a main push does not publish to NuGet
- [ ] Confirm release-please flow still publishes on tagged releases