### PR TITLE
ci: bump release-please-action to @v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           # Manifest mode: read release-please-config.json + .release-please-manifest.json


### PR DESCRIPTION
@v5 uses Node 20+ (v4 was on deprecated Node 16). Standardizes on the action major already used by Rest, AsyncEvents, and Notify.

Refs: ZeroAlloc-Net/.github#14