### PR TITLE
fix(release-please): grant write permissions and use plural output name

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,11 +5,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
@@ -26,7 +30,7 @@ jobs:
 
   publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

The Release Please workflow has been failing on every push to main:

```
Error creating Pull Request: Resource not accessible by integration
POST /repos/.../git/refs → 403
```

NuGet is stuck at the bootstrap `0.0.1` even though there are real `feat:` commits on main (api-compat lock, generator bundling) that should have shipped.

## Root cause

1. **No `permissions:` block** — GITHUB_TOKEN fell back to repo-default read-only scope. `release-please-action` needs `contents: write` to push the release-branch ref and `pull-requests: write` to open the release PR. This is the active blocker — the workflow can't even create the release-please PR.
2. **Latent secondary bug** — outputs were named `release_created` (singular). v5 of `release-please-action` in manifest mode emits `releases_created` (plural). Even with perms fixed, the publish job's `if:` would silently never trigger.

## Changes

- Add the standard `permissions: contents: write / pull-requests: write` block that every other release-please workflow in the org has.
- Rename `release_created` → `releases_created` in both the job-outputs map and the publish-job `if:` guard, with the explicit `== 'true'` comparison used elsewhere in the org.

## Test plan

- [ ] After merge, the next push to main opens a release-please PR (currently 0 release PRs ever opened by the bot).
- [ ] Merging that PR triggers the publish job and lands the new version on NuGet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)