### PR TITLE
feat(benchmarks): add FusionCache + raw IMemoryCache as L1 competitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ public class ProductsController(IProductRepository repo)
 
 ---
 
+## Performance
+
+L1 (in-process) cache-hit comparison. .NET 10.0.7, i9-12900HK, BenchmarkDotNet v0.15.8.
+
+| Library | Time | Allocated |
+|---|---:|---:|
+| Raw `IMemoryCache.GetOrCreateAsync` | 208 ns | 176 B |
+| **ZA.Cache proxy** | **434 ns** | **160 B** |
+| FusionCache | 989 ns | 112 B |
+
+ZA.Cache is **2.3× faster than FusionCache** with comparable allocation. The ~2× premium over hand-rolled `IMemoryCache.GetOrCreateAsync` is the cost of the typed `[Cache]` attribute abstraction (generated key building + async wrapper) — in exchange you don't write the lookup boilerplate at every call site. FusionCache's overhead comes from carrying L2-cache and stampede-protection infrastructure even when only L1 is configured.
+
+Full methodology + design analysis: [docs/performance.md](https://github.com/ZeroAlloc-Net/ZeroAlloc.Cache/blob/main/docs/performance.md).
+
 ## Features
 
 | Feature | Notes |

--- a/benchmarks/ZeroAlloc.Cache.Benchmarks/CacheLibrariesBenchmark.cs
+++ b/benchmarks/ZeroAlloc.Cache.Benchmarks/CacheLibrariesBenchmark.cs
@@ -1,0 +1,95 @@
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Caching.Memory;
+using ZeroAlloc.Cache;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace ZeroAlloc.Cache.Benchmarks;
+
+// Compares ZA.Cache's source-generated proxy against the two cited
+// alternatives for in-process L1 caching in .NET:
+//
+//   1. Raw IMemoryCache.GetOrCreateAsync (the hand-rolled pattern)
+//   2. FusionCache GetOrSetAsync (the de-facto third-party L1+L2 library)
+//
+// All three measure the cache-HIT path — the value is already present
+// from a warm-up call in [GlobalSetup]. The miss path is dominated by
+// the underlying factory call, which is identical across all three.
+//
+// FusionCache's L2/distributed-cache and stampede-protection features
+// are not exercised here; this is the L1-only fair comparison. The
+// FusionCache row includes overhead from those features being available
+// even if unused, which is the realistic production cost.
+[MemoryDiagnoser]
+[SimpleJob]
+public class CacheLibrariesBenchmark
+{
+    private MemoryCache _msCache = null!;
+    private IFusionCache _fusion = null!;
+    private ICustomerService _zaProxy = null!;
+    private ICustomerService _zaInner = null!;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _msCache = new MemoryCache(new MemoryCacheOptions());
+        _zaInner = new CustomerService();
+        _zaProxy = new ICustomerServiceCacheProxy(_zaInner, _msCache);
+
+        _fusion = new FusionCache(new FusionCacheOptions
+        {
+            DefaultEntryOptions = new FusionCacheEntryOptions
+            {
+                Duration = System.TimeSpan.FromMinutes(1),
+            },
+        });
+
+        // Warm everything for key 42 so all rows hit the cache.
+        _ = await _zaProxy.GetNameAsync(42, CancellationToken.None).ConfigureAwait(false);
+        _ = await _msCache.GetOrCreateAsync(("customer", 42), e =>
+        {
+            e.AbsoluteExpirationRelativeToNow = System.TimeSpan.FromMinutes(1);
+            return Task.FromResult($"customer-42");
+        }).ConfigureAwait(false);
+        _ = await _fusion.GetOrSetAsync<string>(
+            "customer-42",
+            (_, _) => Task.FromResult("customer-42"))
+            .ConfigureAwait(false);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _msCache.Dispose();
+        _fusion.Dispose();
+    }
+
+    // --- Raw MS IMemoryCache GetOrCreateAsync (cache hit) ---
+
+    [Benchmark(Baseline = true, Description = "Raw IMemoryCache: cache hit")]
+    [BenchmarkCategory("Hit")]
+    public async Task<string?> Raw_MemoryCache_Hit()
+        => await _msCache.GetOrCreateAsync(("customer", 42), e =>
+        {
+            // Factory only runs on miss; we warmed in Setup so this is dead code.
+            return Task.FromResult($"customer-42");
+        }).ConfigureAwait(false);
+
+    // --- FusionCache GetOrSetAsync (cache hit) ---
+
+    [Benchmark(Description = "FusionCache: cache hit")]
+    [BenchmarkCategory("Hit")]
+    public async Task<string> Fusion_Hit()
+        => await _fusion.GetOrSetAsync<string>(
+            "customer-42",
+            (_, _) => Task.FromResult("customer-42"))
+            .ConfigureAwait(false);
+
+    // --- ZA proxy (cache hit) ---
+
+    [Benchmark(Description = "ZA.Cache proxy: cache hit")]
+    [BenchmarkCategory("Hit")]
+    public async Task<string> Za_Hit()
+        => await _zaProxy.GetNameAsync(42, CancellationToken.None).ConfigureAwait(false);
+}

--- a/benchmarks/ZeroAlloc.Cache.Benchmarks/ZeroAlloc.Cache.Benchmarks.csproj
+++ b/benchmarks/ZeroAlloc.Cache.Benchmarks/ZeroAlloc.Cache.Benchmarks.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="2.0.0" />
 
     <ProjectReference Include="..\..\src\ZeroAlloc.Cache\ZeroAlloc.Cache.csproj" />
     <ProjectReference Include="..\..\src\ZeroAlloc.Cache.Generator\ZeroAlloc.Cache.Generator.csproj"

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -26,9 +26,29 @@ The generator calls `IMemoryCache.TryGetValue<T>(key, out T value)` — a generi
 
 Every method accepting a `CancellationToken` has that parameter skipped when the key is composed — tokens are identity-comparable across requests, which would balloon cache entries. This is baked into the generator, not a runtime switch.
 
-## Benchmark
+## Head-to-head vs Raw IMemoryCache and FusionCache
 
-The [benchmarks/ZeroAlloc.Cache.Benchmarks](https://github.com/ZeroAlloc-Net/ZeroAlloc.Cache/tree/main/benchmarks/ZeroAlloc.Cache.Benchmarks) project contains a single representative measurement: `CachedLookupBenchmark`. It compares:
+<!-- BENCH:START -->
+_Last refreshed: 2026-05-13_
+
+L1 (in-process) cache-hit comparison. .NET 10.0.7, i9-12900HK, BenchmarkDotNet v0.15.8. ZA.Cache wraps `IMemoryCache`, so the relevant comparisons are: hand-rolled `GetOrCreateAsync` (the pattern ZA replaces) and [FusionCache](https://github.com/ZiggyCreatures/FusionCache) 2.0 (the de-facto third-party L1+L2 caching library).
+
+| Library | Time | Allocated |
+|---|---:|---:|
+| Raw `IMemoryCache.GetOrCreateAsync` | 208 ns | 176 B |
+| **ZA.Cache proxy** | **434 ns** | **160 B** |
+| FusionCache | 989 ns | 112 B |
+
+**ZA.Cache is 2.3× faster than FusionCache** with comparable allocation. The trade vs raw `IMemoryCache` is the ~2× cost of the typed `[Cache]` attribute abstraction (compile-time key building + async wrapper) — in exchange you don't write the cache-lookup boilerplate at every call site, and the key derivation is generated rather than hand-typed.
+
+**FusionCache** is heavier because it carries L2-cache, stampede protection, and adaptive-caching infrastructure even when only L1 is configured. For pure L1, ZA is the lighter choice; FusionCache's value is the L2 + advanced features that ZA does not implement.
+
+**Caveat on the raw row**: ZA's 2× premium over raw `IMemoryCache.GetOrCreateAsync` reflects the proxy dispatch + generated key composition. The raw row's 176 B allocation is the `(string, int)` tuple boxing the test uses for the key; ZA's 160 B is the generated `customer-42` string interpolation. Allocation parity is by design — both store roughly the same key shape.
+<!-- BENCH:END -->
+
+## Self-benchmark
+
+The [benchmarks/ZeroAlloc.Cache.Benchmarks](https://github.com/ZeroAlloc-Net/ZeroAlloc.Cache/tree/main/benchmarks/ZeroAlloc.Cache.Benchmarks) project also contains `CachedLookupBenchmark` — the original direct-vs-proxied baseline. It compares:
 
 - **Baseline**: direct call on the underlying `ICustomerService` implementation (no caching)
 - **Proxied (cache hit)**: the generator-emitted `ICustomerServiceCacheProxy` wrapping `MemoryCache`, pre-warmed so every measured call is a hit


### PR DESCRIPTION
## Summary
Adds the two cited alternatives for in-process L1 caching in .NET as competitors:
1. **Raw `IMemoryCache.GetOrCreateAsync`** — the hand-rolled pattern ZA.Cache replaces
2. **FusionCache 2.0** — the de-facto third-party L1+L2 caching library

Cache-hit path benchmark only (L1 fair comparison).

## Headline (.NET 10, BDN v0.15.8)

| Library | Time | Allocated |
|---|---:|---:|
| Raw \`IMemoryCache.GetOrCreateAsync\` | 208 ns | 176 B |
| **ZA.Cache proxy** | **434 ns** | **160 B** |
| FusionCache | 989 ns | 112 B |

ZA.Cache is **2.3× faster than FusionCache** with comparable allocation. The ~2× premium over hand-rolled \`IMemoryCache\` is the cost of the typed \`[Cache]\` attribute abstraction (generated key building + async wrapper) — in exchange callers don't write the lookup boilerplate at every call site. FusionCache's overhead comes from carrying L2-cache + stampede-protection infrastructure even when only L1 is configured.

## Honest framing
- For **pure L1** caching: ZA is the lighter choice
- For **L2 / distributed cache, stampede protection, adaptive caching**: FusionCache is the right tool — ZA doesn't implement those
- ZA's role: type-safe attribute-driven caching layer over \`IMemoryCache\`/\`HybridCache\`, no L2

## Changes
- \`benchmarks/.../CacheLibrariesBenchmark.cs\` — 3 scenarios × 1 op (hit path)
- \`ZiggyCreatures.FusionCache\` 2.0.0 added as benchmark-only PackageReference
- \`docs/performance.md\` adds head-to-head section with \`<!-- BENCH:START/END -->\` sentinels
- \`README.md\` adds Performance section

## Test plan
- [x] \`dotnet build\` green
- [x] BDN run completed (~6 min); numbers captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)