### PR TITLE
chore(deps): replace FluentAssertions with AwesomeAssertions

### DIFF
--- a/tests/ZeroAlloc.Cache.Generator.Tests/ZeroAlloc.Cache.Generator.Tests.csproj
+++ b/tests/ZeroAlloc.Cache.Generator.Tests/ZeroAlloc.Cache.Generator.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
-    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.8.0" />
     <PackageReference Include="Verify.Xunit" Version="31.12.5" />
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />
-    <Using Include="FluentAssertions" />
+    <Using Include="AwesomeAssertions" />
     <Using Include="VerifyXunit" />
   </ItemGroup>
 </Project>

--- a/tests/ZeroAlloc.Cache.Tests/ZeroAlloc.Cache.Tests.csproj
+++ b/tests/ZeroAlloc.Cache.Tests/ZeroAlloc.Cache.Tests.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
-    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.8.0" />
@@ -19,6 +19,6 @@
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />
-    <Using Include="FluentAssertions" />
+    <Using Include="AwesomeAssertions" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why not simply take FluentAssertions 8

FluentAssertions changed licence at v8. Read from the packages, not from memory:

| Version | `<license>` |
|---|---|
| 6.12.2 | expression — **Apache-2.0** |
| 7.2.0 | expression — **Apache-2.0** |
| **8.10.0** | file — **Xceed Community License** |

From v8's `LICENSE` file:

> Non-Commercial Use means the software is used in **open-source, personal or experimental** projects, and **"is not being used by or for an organisation … that charges fees or earns revenues"**.
>
> *"Any use outside of these parameters requires a paid Commercial License from Xceed."*

That is a licensing decision rather than a version bump — and because these are published packages, it reaches consumers too.

## AwesomeAssertions

The community fork that stayed open source. Verified from the package:

```
AwesomeAssertions 9.5.0   license expression: Apache-2.0
lib: net47, net6.0, net8.0, netstandard2.0, netstandard2.1
```

**Not a pure drop-in.** 9.x renames the root namespace — confirmed by inspecting the assembly, which exports `AwesomeAssertions.Numeric`, `AwesomeAssertions.Primitives` and `AwesomeAssertions.Execution` and contains no `FluentAssertions` namespace. So this PR moves three things together:

- `<PackageReference Include="FluentAssertions" …>` → `AwesomeAssertions` 9.5.0
- `<Using Include="FluentAssertions" />` → `AwesomeAssertions`
- `using FluentAssertions;` → `using AwesomeAssertions;`

The fork tracks the v7/v8 API, so any v6-era call sites rename with it (`BeGreaterOrEqualTo` → `BeGreaterThanOrEqualTo`).

## Verification

Clean Release build and the full suite for this repo — build **exit 0**, all test assemblies green, and **no test was adjusted** beyond the API renames noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
